### PR TITLE
Update api secret handling

### DIFF
--- a/JennyWeather.xcodeproj/project.pbxproj
+++ b/JennyWeather.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B1339AD2610102A0092BF53 /* DarkSkyNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */; };
 		8B1A0988242FFB3D005C3ACE /* UserDefaultsUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1A0987242FFB3D005C3ACE /* UserDefaultsUtility.swift */; };
 		8B1C7E972467530C007666AD /* WeatherDailyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C7E962467530C007666AD /* WeatherDailyDTO.swift */; };
 		8B1C7E99246755C5007666AD /* WeatherDayDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C7E98246755C5007666AD /* WeatherDayDTO.swift */; };
@@ -74,6 +75,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkSkyNetworkManager.swift; sourceTree = "<group>"; };
 		8B1A0987242FFB3D005C3ACE /* UserDefaultsUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsUtility.swift; sourceTree = "<group>"; };
 		8B1C7E962467530C007666AD /* WeatherDailyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDailyDTO.swift; sourceTree = "<group>"; };
 		8B1C7E98246755C5007666AD /* WeatherDayDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDayDTO.swift; sourceTree = "<group>"; };
@@ -154,6 +156,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8B1339B12610103A0092BF53 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		8B1C7E94246751D9007666AD /* Currently */ = {
 			isa = PBXGroup;
 			children = (
@@ -359,6 +369,7 @@
 			children = (
 				8B711FF124569DA80061A21F /* DTO */,
 				8B4186FD23F3C49300BA7307 /* DataService */,
+				8B1339B12610103A0092BF53 /* Manager */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -662,6 +673,7 @@
 				8B9155C524272516008826D0 /* LocationManager.swift in Sources */,
 				8B41870623F3DAC200BA7307 /* WeatherCurrentlyViewModel.swift in Sources */,
 				8B41870223F3CE5900BA7307 /* JWErrors.swift in Sources */,
+				8B1339AD2610102A0092BF53 /* DarkSkyNetworkManager.swift in Sources */,
 				8BEB8593242DD942005142F9 /* SearchCompletionResultDTO.swift in Sources */,
 				8B9155C22426E9AC008826D0 /* CityLocationViewModel.swift in Sources */,
 				8B41870023F3C61600BA7307 /* NetworkUtility.swift in Sources */,

--- a/JennyWeather.xcodeproj/project.pbxproj
+++ b/JennyWeather.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8B1339AD2610102A0092BF53 /* DarkSkyNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */; };
+		8B1339B82610215D0092BF53 /* CloudKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1339B72610215D0092BF53 /* CloudKitManager.swift */; };
 		8B1A0988242FFB3D005C3ACE /* UserDefaultsUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1A0987242FFB3D005C3ACE /* UserDefaultsUtility.swift */; };
 		8B1C7E972467530C007666AD /* WeatherDailyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C7E962467530C007666AD /* WeatherDailyDTO.swift */; };
 		8B1C7E99246755C5007666AD /* WeatherDayDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C7E98246755C5007666AD /* WeatherDayDTO.swift */; };
@@ -76,6 +77,7 @@
 
 /* Begin PBXFileReference section */
 		8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkSkyNetworkManager.swift; sourceTree = "<group>"; };
+		8B1339B72610215D0092BF53 /* CloudKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitManager.swift; sourceTree = "<group>"; };
 		8B1A0987242FFB3D005C3ACE /* UserDefaultsUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsUtility.swift; sourceTree = "<group>"; };
 		8B1C7E962467530C007666AD /* WeatherDailyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDailyDTO.swift; sourceTree = "<group>"; };
 		8B1C7E98246755C5007666AD /* WeatherDayDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDayDTO.swift; sourceTree = "<group>"; };
@@ -162,6 +164,14 @@
 				8B1339AC2610102A0092BF53 /* DarkSkyNetworkManager.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		8B1339B62610214E0092BF53 /* CloudKit */ = {
+			isa = PBXGroup;
+			children = (
+				8B1339B72610215D0092BF53 /* CloudKitManager.swift */,
+			);
+			path = CloudKit;
 			sourceTree = "<group>";
 		};
 		8B1C7E94246751D9007666AD /* Currently */ = {
@@ -463,6 +473,7 @@
 		8B9155C3242724AF008826D0 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				8B1339B62610214E0092BF53 /* CloudKit */,
 				8B1D25C624F20A40009826CE /* Fun Manager */,
 				8B9155C624283B81008826D0 /* Location */,
 				8B9A909C25071FFC0005D142 /* Theme Manager */,
@@ -689,6 +700,7 @@
 				8B9A909E250720110005D142 /* ThemeManager.swift in Sources */,
 				8B1D25C824F20A60009826CE /* FunManager.swift in Sources */,
 				8B1C7EA2246759B3007666AD /* WeatherMinutelyDTO.swift in Sources */,
+				8B1339B82610215D0092BF53 /* CloudKitManager.swift in Sources */,
 				8B4186FC23F3BE6D00BA7307 /* WeatherHourlyViewModel.swift in Sources */,
 				8B6D91AB240C5F9E0015CAC7 /* WeatherLocationViewModel.swift in Sources */,
 				8B46DB9624079C5500333783 /* WeatherDailyView.swift in Sources */,

--- a/JennyWeather/Globals/Jenny Weather.entitlements
+++ b/JennyWeather/Globals/Jenny Weather.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.bap034.JennyWeather</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>

--- a/JennyWeather/Managers/CloudKit/CloudKitManager.swift
+++ b/JennyWeather/Managers/CloudKit/CloudKitManager.swift
@@ -1,0 +1,60 @@
+//
+//  CloudKitManager.swift
+//  JennyWeather
+//
+//  Created by Brett Petersen on 3/27/21.
+//  Copyright © 2021 Brett Petersen. All rights reserved.
+//
+
+import Foundation
+import CloudKit
+
+struct Secret: Codable {
+	let darkSkyAPI: String
+}
+
+class CloudKitManager {
+	
+	private static let publicDatabase = CKContainer.default().publicCloudDatabase
+	private static let zoneId = CKRecordZone.default().zoneID
+	private static let secretsRecordType = "Secrets"
+	
+	static func retrieveSecret(success: ((Secret)->Void)?, failure: (()->Void)?) {
+		let predicate = NSPredicate(value: true)
+		let query = CKQuery(recordType: secretsRecordType, predicate: predicate)
+		publicDatabase.perform(query, inZoneWith: zoneId) { (records, error) in
+			guard let sureRecord = records?.first else {
+				print(">>> error: \(String(describing: error?.localizedDescription))")
+				failure?()
+				return
+			}
+			guard let secret: Secret = sureRecord.toCodable() else {
+				failure?()
+				return
+			}
+			
+			success?(secret)
+		}
+	}
+}
+
+// MARK: - Utility Methods
+extension CKRecord {
+	func toJson() -> [String: Any] {
+		var json = [String: Any]()
+		
+		allKeys().forEach { (key) in
+			guard let sureValue = value(forKey: key) else { return }
+			
+			json[key] = sureValue
+		}
+		
+		return json
+	}
+	
+	func toCodable<T: Codable>() -> T? {
+		let json = toJson()
+		let codable: T? = try? NetworkUtility.codableFromJSON(json)
+		return codable
+	}
+}

--- a/JennyWeather/Network/Manager/DarkSkyNetworkManager.swift
+++ b/JennyWeather/Network/Manager/DarkSkyNetworkManager.swift
@@ -1,0 +1,50 @@
+//
+//  DarkSkyNetworkManager.swift
+//  JennyWeather
+//
+//  Created by Brett Petersen on 3/27/21.
+//  Copyright © 2021 Brett Petersen. All rights reserved.
+//
+
+import Foundation
+
+
+class DarkSkyNetworkManager: NSObject, URLSessionDataDelegate {
+	static let shared = DarkSkyNetworkManager()
+	
+	private var secretKey = "9e81c40beac3dc5695160dec5db8258b"
+	private var baseURLString: String { return "https://api.darksky.net/forecast/\(secretKey)/" }
+	private var urlSession: URLSession?
+	private var observation: NSKeyValueObservation?
+	
+	override init() {
+		super.init()
+		
+		let configuration = URLSessionConfiguration.default
+		let delegate = self
+		urlSession = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+	}
+	
+}
+
+// API Methods
+extension DarkSkyNetworkManager {	
+	/// The `urlString` parameter is appended to the `baseURLString` property. Omit leading`/` from the `urlString` value.
+	func sendForecastRequest(urlString: String, completion: @escaping (Data?, URLResponse?, Error?)->Void) {
+		let fullURLString = baseURLString + urlString
+		guard let url = URL(string: fullURLString) else {
+			completion(nil, nil, JWError.unexpectedNil)
+			return
+		}
+		
+		let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 10)
+		let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
+			completion(data, response, error)
+		}
+		
+		observation = dataTask.progress.observe(\.fractionCompleted) { progress, _ in
+			print("progress: ", progress.fractionCompleted)
+		}
+		dataTask.resume()
+	}
+}

--- a/JennyWeather/Network/Manager/DarkSkyNetworkManager.swift
+++ b/JennyWeather/Network/Manager/DarkSkyNetworkManager.swift
@@ -8,11 +8,10 @@
 
 import Foundation
 
-
 class DarkSkyNetworkManager: NSObject, URLSessionDataDelegate {
 	static let shared = DarkSkyNetworkManager()
 	
-	private var secretKey = "9e81c40beac3dc5695160dec5db8258b"
+	private var secretKey = "placeholder"
 	private var baseURLString: String { return "https://api.darksky.net/forecast/\(secretKey)/" }
 	private var urlSession: URLSession?
 	private var observation: NSKeyValueObservation?
@@ -28,12 +27,22 @@ class DarkSkyNetworkManager: NSObject, URLSessionDataDelegate {
 }
 
 // API Methods
-extension DarkSkyNetworkManager {	
+extension DarkSkyNetworkManager {
+	func updateSecretKey(success: (()->Void)?, failure: (()->Void)?) {
+		CloudKitManager.retrieveSecret { [weak self] (secret) in
+			self?.secretKey = secret.darkSkyAPI
+			success?()
+		} failure: {
+			failure?()
+		}
+	}
+	
 	/// The `urlString` parameter is appended to the `baseURLString` property. Omit leading`/` from the `urlString` value.
 	func sendForecastRequest(urlString: String, completion: @escaping (Data?, URLResponse?, Error?)->Void) {
 		let fullURLString = baseURLString + urlString
 		guard let url = URL(string: fullURLString) else {
-			completion(nil, nil, JWError.unexpectedNil)
+			let errorMessage = "Ah, sorry sorry!\n\nAn error occurred when trying to retrieve weather data. Please make sure you are on the latest app version and try again later."
+			completion(nil, nil, JWError(type: .unexpectedNil, message: errorMessage))
 			return
 		}
 		

--- a/JennyWeather/Utility/Categories/String+JW.swift
+++ b/JennyWeather/Utility/Categories/String+JW.swift
@@ -10,9 +10,9 @@ import Foundation
 
 extension String {
 	func toJson() throws -> [String: Any] {
-		guard let jsonData = data(using: .utf8) else { throw JWError.unexpectedNil }
+		guard let jsonData = data(using: .utf8) else { throw JWError(type: .unexpectedNil, message: "unexpected nil JSON data") }
 		let jsonAnyObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
-		guard let json = jsonAnyObject as? [String: Any] else { throw JWError.unexpectedNil }
+		guard let json = jsonAnyObject as? [String: Any] else { throw JWError(type: .unexpectedNil, message: "unexpected nil JSON object") }
 		
 		return json
 	}

--- a/JennyWeather/Utility/Errors/JWErrors.swift
+++ b/JennyWeather/Utility/Errors/JWErrors.swift
@@ -9,8 +9,23 @@
 import Foundation
 
 // MARK: - JW Errors
-enum JWError: Error {
-	case unexpectedNil
+class JWError: LocalizedError {
+	enum JWErrorType {
+		case unexpectedNil
+	}
+	
+	let type: JWErrorType
+	let message: String?
+	
+	var errorDescription: String? {
+		return message ?? localizedDescription
+	}
+
+	init(type: JWError.JWErrorType, message: String? = nil) {
+		self.type = type
+		self.message = message
+	}
+	
 }
 
 // MARK: - JSON Errors


### PR DESCRIPTION
Improved handling of the DarkSky API secret. We can now revoke+update it via CloudKit without requiring a new release.